### PR TITLE
bump yargs-parser and npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11120,6 +11120,16 @@
             "which-module": "^2.0.0",
             "y18n": "^3.2.1",
             "yargs-parser": "^7.0.0"
+          },
+          "dependencies": {
+            "yargs-parser": {
+              "version": "7.0.0",
+              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
+              "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+              "requires": {
+                "camelcase": "^4.1.0"
+              }
+            }
           }
         }
       }
@@ -12630,6 +12640,16 @@
             "which-module": "^2.0.0",
             "y18n": "^3.2.1",
             "yargs-parser": "^7.0.0"
+          },
+          "dependencies": {
+            "yargs-parser": {
+              "version": "7.0.0",
+              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
+              "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+              "requires": {
+                "camelcase": "^4.1.0"
+              }
+            }
           }
         }
       }
@@ -15760,15 +15780,22 @@
         "which-module": "^2.0.0",
         "y18n": "^3.2.1",
         "yargs-parser": "^7.0.0"
+      },
+      "dependencies": {
+        "yargs-parser": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
+          "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+          "requires": {
+            "camelcase": "^4.1.0"
+          }
+        }
       }
     },
     "yargs-parser": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
-      "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
-      "requires": {
-        "camelcase": "^4.1.0"
-      }
+      "version": "19.0.4",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-19.0.4.tgz",
+      "integrity": "sha512-eXeQm7yXRjPFFyf1voPkZgXQZJjYfjgQUmGPbD2TLtZeIYzvacgWX7sQ5a1HsRgVP+pfKAkRZDNtTGev4h9vhw=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "react-navigation": "^3.0.9",
     "set-value": "^3.0.1",
     "webpack": "^4.39.3",
-    "ws": "^7.1.0"
+    "ws": "^7.1.0",
+    "yargs-parser": "^19.0.4"
   },
   "devDependencies": {
     "babel-preset-expo": "^5.0.0",


### PR DESCRIPTION
Details
GHSA-p9pc-299p-vxgp
low severity
Vulnerable versions: < 13.1.2
Patched version: 13.1.2